### PR TITLE
Update TimescaleDB dialect to convert Timestamp format to Timestamptz

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.5.0</version>
     </parent>
 
     <groupId>io.confluent</groupId>
@@ -72,7 +72,7 @@
         <repository>
             <id>confluent</id>
             <name>Confluent</name>
-            <url>${confluent.maven.repo}</url>
+            <url>http://packages.confluent.io/maven/</url>
         </repository>
     </repositories>
 

--- a/src/main/java/io/confluent/connect/jdbc/dialect/TimescaleDBDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/TimescaleDBDatabaseDialect.java
@@ -17,12 +17,15 @@ package io.confluent.connect.jdbc.dialect;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialectProvider.SubprotocolBasedProvider;
 import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
-import io.confluent.connect.jdbc.util.*;
+import io.confluent.connect.jdbc.util.DateTimeUtils;
+import io.confluent.connect.jdbc.util.ExpressionBuilder;
+import io.confluent.connect.jdbc.util.TableId;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Timestamp;
 
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -67,8 +70,9 @@ public class TimescaleDBDatabaseDialect extends PostgreSqlDatabaseDialect {
   ) {
     // This would create the schema and table then convert the table to a hyper table.
     List<String> sqlQueries = new ArrayList<>();
-    if(table.schemaName() != null)
+    if (table.schemaName() != null) {
       sqlQueries.add(buildCreateSchemaStatement(table));
+    }
     sqlQueries.add(super.buildCreateTableStatement(table, fields));
     sqlQueries.add(buildCreateHyperTableStatement(table));
 
@@ -104,21 +108,22 @@ public class TimescaleDBDatabaseDialect extends PostgreSqlDatabaseDialect {
           Connection connection,
           List<String> statements
   ) throws SQLException {
-    // This overrides the function by catching 'result was returned' error thrown by PSQL when creating hypertables
-    try{
+    // This overrides the function by catching 'result was returned' error thrown by PSQL
+    // when creating hypertables
+    try {
       super.applyDdlStatements(connection, statements);
-    }
-    catch(SQLException e){
-      if(!e.getMessage().contains(HYPERTABLE_WARNING))
+    } catch (SQLException e) {
+      if (!e.getMessage().contains(HYPERTABLE_WARNING)) {
         throw e;
+      }
     }
   }
 
   @Override
   protected String getSqlType(SinkRecordField field) {
-    if (field.schemaName() == Timestamp.LOGICAL_NAME)
+    if (field.schemaName() == Timestamp.LOGICAL_NAME) {
       return "TIMESTAMPTZ";
-    else {
+    } else {
       return super.getSqlType(field);
     }
   }

--- a/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
@@ -21,7 +21,10 @@ import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialect;
 import io.confluent.connect.jdbc.sink.metadata.FieldsMetadata;
@@ -85,7 +88,8 @@ public class DbStructure {
           String.format("Table %s is missing and auto-creation is disabled", tableId)
       );
     }
-    List<String> sql = dbDialect.buildCreateTableStatements(tableId, fieldsMetadata.allFields.values());
+    List<String> sql = dbDialect.buildCreateTableStatements(tableId,
+            fieldsMetadata.allFields.values());
     log.info("Creating table with sql: {}", sql);
     dbDialect.applyDdlStatements(connection, sql);
   }

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -103,19 +103,20 @@ public class JdbcDbWriter {
   }
 
   String destinationSchema(SinkRecord record) {
-    String schemaNameFormat = config.schemaNameFormat;
-    Struct keyData = ((Struct)record.key());
-
     StringBuilder schemaName = new StringBuilder();
-    Pattern pattern = Pattern.compile("\\$\\{(.*?)\\}");
-    Matcher matcher = pattern.matcher(schemaNameFormat);
-    int lastStart = 0;
-    while (matcher.find()) {
-      String subString = schemaNameFormat.substring(lastStart,matcher.start());
-      String key = matcher.group(1);
-      String replacement = keyData.getString(key);
-      schemaName.append(subString).append(replacement);
-      lastStart = matcher.end();
+    String schemaNameFormat = config.schemaNameFormat;
+    if (!schemaNameFormat.isEmpty() && (record.key() instanceof Struct)) {
+      Struct keyData = ((Struct) record.key());
+      Pattern pattern = Pattern.compile("\\$\\{(.*?)\\}");
+      Matcher matcher = pattern.matcher(schemaNameFormat);
+      int lastStart = 0;
+      while (matcher.find()) {
+        String subString = schemaNameFormat.substring(lastStart, matcher.start());
+        String key = matcher.group(1);
+        String replacement = keyData.getString(key);
+        schemaName.append(subString).append(replacement);
+        lastStart = matcher.end();
+      }
     }
 
     return schemaName.toString().toLowerCase();

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -85,7 +85,9 @@ public class JdbcDbWriter {
   TableId destinationTable(SinkRecord record) {
     StringBuilder name = new StringBuilder();
     final String schemaName = destinationSchema(record);
-    if (!schemaName.isEmpty()) name.append(schemaName).append(".");
+    if (!schemaName.isEmpty()) {
+      name.append(schemaName).append(".");
+    }
     name.append(config.tableNameFormat.replace("${topic}", record.topic()));
 
     final String tableName = name.toString();

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -117,6 +117,7 @@ public class JdbcDbWriter {
         schemaName.append(subString).append(replacement);
         lastStart = matcher.end();
       }
+      schemaName.append(schemaNameFormat.substring(lastStart));
     }
 
     return schemaName.toString().toLowerCase();

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -95,7 +95,7 @@ public class JdbcSinkConfig extends AbstractConfig {
   private static final String TABLE_NAME_FORMAT_DISPLAY = "Table Name Format";
 
   public static final String SCHEMA_NAME_FORMAT = "schema.name.format";
-  private static final String SCHEMA_NAME_FORMAT_DEFAULT = "";
+  private static final String SCHEMA_NAME_FORMAT_DEFAULT = "public";
   private static final String SCHEMA_NAME_FORMAT_DOC =
           "A format string for the destination schema name, which may contain '${key}' as a "
           + "placeholder for a key in the record key."

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -99,7 +99,8 @@ public class JdbcSinkConfig extends AbstractConfig {
   private static final String SCHEMA_NAME_FORMAT_DOC =
           "A format string for the destination schema name, which may contain '${key}' as a "
           + "placeholder for a key in the record key."
-          + "For example, ``${projectId}`` for projectId 'myProject' will map to the schema name 'myProject'.";
+          + "For example, ``${projectId}`` for projectId 'myProject' "
+          + "will map to the schema name 'myProject'.";
   private static final String SCHEMA_NAME_FORMAT_DISPLAY = "Schema Name Format";
 
   public static final String MAX_RETRIES = "max.retries";

--- a/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
@@ -65,6 +65,14 @@ public class DateTimeUtils {
     }).format(date);
   }
 
+  public static String formatTimestamptz(Date date, TimeZone timeZone) {
+    return TIMEZONE_TIMESTAMP_FORMATS.get().computeIfAbsent(timeZone, aTimeZone -> {
+      SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSX");
+      sdf.setTimeZone(aTimeZone);
+      return sdf;
+    }).format(date);
+  }
+
   private DateTimeUtils() {
   }
 }


### PR DESCRIPTION
- Override PostGresDB dialect functions to convert `Timestamp` field format to `Timestamptz` and take `timezone` into account.
- The `timezone` config is already a config in the jdbc connector
https://github.com/mpgxvii/kafka-connect-jdbc/blob/573cda83cc2081f12ad1798845b7a6b51450c80d/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java#L212-L217