### PR TITLE
Release 6.0.0-5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.5.0</version>
     </parent>
 
     <groupId>io.confluent</groupId>
@@ -72,7 +72,7 @@
         <repository>
             <id>confluent</id>
             <name>Confluent</name>
-            <url>${confluent.maven.repo}</url>
+            <url>http://packages.confluent.io/maven/</url>
         </repository>
     </repositories>
 

--- a/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
@@ -395,8 +395,6 @@ public interface DatabaseDialect extends ConnectionProvider {
    */
   String buildCreateTableStatement(TableId table, Collection<SinkRecordField> fields);
 
-  String buildCreateSchemaStatement(TableId table);
-
   /**
    * Build the CREATE TABLE statement expression for the given table and its columns.
    *

--- a/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
@@ -396,6 +396,15 @@ public interface DatabaseDialect extends ConnectionProvider {
   String buildCreateTableStatement(TableId table, Collection<SinkRecordField> fields);
 
   /**
+   * Build the CREATE TABLE statement expression for the given table and its columns.
+   *
+   * @param table  the identifier of the table; may not be null
+   * @param fields the information about the fields in the sink records; may not be null
+   * @return the CREATE TABLE statement; may not be null
+   */
+  List<String> buildCreateTableStatements(TableId table, Collection<SinkRecordField> fields);
+
+  /**
    * Build the ALTER TABLE statement expression for the given table and its columns.
    *
    * @param table  the identifier of the table; may not be null

--- a/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/DatabaseDialect.java
@@ -395,6 +395,8 @@ public interface DatabaseDialect extends ConnectionProvider {
    */
   String buildCreateTableStatement(TableId table, Collection<SinkRecordField> fields);
 
+  String buildCreateSchemaStatement(TableId table);
+
   /**
    * Build the ALTER TABLE statement expression for the given table and its columns.
    *

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1660,6 +1660,7 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     return builder.toString();
   }
 
+  @Override
   public List<String> buildCreateTableStatements(
           TableId table,
           Collection<SinkRecordField> fields

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1661,6 +1661,16 @@ public class GenericDatabaseDialect implements DatabaseDialect {
   }
 
   @Override
+  public List<String> buildCreateTableStatements(
+          TableId table,
+          Collection<SinkRecordField> fields
+  ) {
+    String sql = buildCreateTableStatement(table, fields);
+    return Collections.singletonList(sql);
+  }
+
+
+  @Override
   public String buildDropTableStatement(
       TableId table,
       DropOptions options

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1660,13 +1660,6 @@ public class GenericDatabaseDialect implements DatabaseDialect {
     return builder.toString();
   }
 
-  @Override
-  public String buildCreateSchemaStatement(
-          TableId table
-  ) {
-    return null;
-  }
-
   public List<String> buildCreateTableStatements(
           TableId table,
           Collection<SinkRecordField> fields

--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -1661,6 +1661,13 @@ public class GenericDatabaseDialect implements DatabaseDialect {
   }
 
   @Override
+  public String buildCreateSchemaStatement(
+          TableId table
+  ) {
+    return null;
+  }
+
+  @Override
   public String buildDropTableStatement(
       TableId table,
       DropOptions options

--- a/src/main/java/io/confluent/connect/jdbc/dialect/TimescaleDBDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/TimescaleDBDatabaseDialect.java
@@ -64,8 +64,8 @@ public class TimescaleDBDatabaseDialect extends PostgreSqlDatabaseDialect {
   ) {
     // This would create the table then convert it to a hyper table.
     List<String> sqlQueries = new ArrayList<>();
-    sqlQueries.add(buildCreateSchemaStatement(tableId));
-    sqlQueries.add(buildSetSearchPathStatement(tableId));
+    sqlQueries.add(buildCreateSchemaStatement(table));
+    sqlQueries.add(buildSetSearchPathStatement(table));
     sqlQueries.add(super.buildCreateTableStatement(table, fields));
     sqlQueries.add(buildCreateHyperTableStatement(table));
 

--- a/src/main/java/io/confluent/connect/jdbc/dialect/TimescaleDBDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/TimescaleDBDatabaseDialect.java
@@ -62,10 +62,10 @@ public class TimescaleDBDatabaseDialect extends PostgreSqlDatabaseDialect {
           TableId table,
           Collection<SinkRecordField> fields
   ) {
-    // This would create the table then convert it to a hyper table.
+    // This would create the schema and table then convert the table to a hyper table.
     List<String> sqlQueries = new ArrayList<>();
-    sqlQueries.add(buildCreateSchemaStatement(table));
-    sqlQueries.add(buildSetSearchPathStatement(table));
+    if(table.schemaName() != null)
+      sqlQueries.add(buildCreateSchemaStatement(table));
     sqlQueries.add(super.buildCreateTableStatement(table, fields));
     sqlQueries.add(buildCreateHyperTableStatement(table));
 
@@ -78,8 +78,8 @@ public class TimescaleDBDatabaseDialect extends PostgreSqlDatabaseDialect {
   ) {
     ExpressionBuilder builder = expressionBuilder();
 
-    builder.append("SELECT public.create_hypertable('");
-    builder.append(table.tableName());
+    builder.append("SELECT create_hypertable('");
+    builder.append(table);
     builder.append("', 'time', migrate_data => TRUE, chunk_time_interval => ");
     builder.append(CHUNK_TIME_INTERVAL);
     builder.append(");");
@@ -91,17 +91,7 @@ public class TimescaleDBDatabaseDialect extends PostgreSqlDatabaseDialect {
   ) {
     ExpressionBuilder builder = expressionBuilder();
 
-    builder.append("CREATE SCHEMA ");
-    builder.append(table.schemaName());
-    return builder.toString();
-  }
-
-  public String buildSetSearchPathStatement(
-          TableId table
-  ) {
-    ExpressionBuilder builder = expressionBuilder();
-
-    builder.append("SET search_path to ");
+    builder.append("CREATE SCHEMA IF NOT EXISTS ");
     builder.append(table.schemaName());
     return builder.toString();
   }

--- a/src/main/java/io/confluent/connect/jdbc/dialect/TimescaleDBDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/TimescaleDBDatabaseDialect.java
@@ -61,11 +61,12 @@ public class TimescaleDBDatabaseDialect extends PostgreSqlDatabaseDialect {
   ) {
     ExpressionBuilder builder = expressionBuilder();
 
-    builder.append("SELECT create_hypertable('");
-    builder.append(table);
-    builder.append("', 'time', migrate_data => TRUE, chunk_time_interval => ");
-    builder.append(CHUNK_TIME_INTERVAL);
-    builder.append(");");
+    builder.append("CREATE SCHEMA ");
+    builder.append(table.schemaName());
+    builder.append(DELIMITER);
+    builder.append("SET search_path to ");
+    builder.append(table.schemaName());
+    builder.append(DELIMITER);
     return builder.toString();
   }
 
@@ -75,7 +76,11 @@ public class TimescaleDBDatabaseDialect extends PostgreSqlDatabaseDialect {
           Collection<SinkRecordField> fields
   ) {
     // This would create the table then convert it to a hyper table.
-    return super.buildCreateTableStatement(table, fields).concat(DELIMITER).concat(buildCreateHyperTableStatement(table));
+    ExpressionBuilder builder = expressionBuilder();
+    builder.append(super.buildCreateTableStatement(parseTableIdentifier(table.tableName()), fields));
+    builder.append(DELIMITER);
+    builder.append(buildCreateHyperTableStatement(parseTableIdentifier(table.tableName())));
+    return builder.toString();
   }
 
 
@@ -84,8 +89,8 @@ public class TimescaleDBDatabaseDialect extends PostgreSqlDatabaseDialect {
   ) {
     ExpressionBuilder builder = expressionBuilder();
 
-    builder.append("SELECT create_hypertable('");
-    builder.append(table);
+    builder.append("SELECT public.create_hypertable('");
+    builder.append(table.tableName());
     builder.append("', 'time', migrate_data => TRUE, chunk_time_interval => ");
     builder.append(CHUNK_TIME_INTERVAL);
     builder.append(");");

--- a/src/main/java/io/confluent/connect/jdbc/dialect/TimescaleDBDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/TimescaleDBDatabaseDialect.java
@@ -65,6 +65,7 @@ public class TimescaleDBDatabaseDialect extends PostgreSqlDatabaseDialect {
     // This would create the table then convert it to a hyper table.
     List<String> sqlQueries = new ArrayList<>();
     sqlQueries.add(buildCreateSchemaStatement(tableId));
+    sqlQueries.add(buildSetSearchPathStatement(tableId));
     sqlQueries.add(super.buildCreateTableStatement(table, fields));
     sqlQueries.add(buildCreateHyperTableStatement(table));
 
@@ -85,17 +86,23 @@ public class TimescaleDBDatabaseDialect extends PostgreSqlDatabaseDialect {
     return builder.toString();
   }
 
-    public String buildCreateSchemaStatement(
+  public String buildCreateSchemaStatement(
           TableId table
   ) {
     ExpressionBuilder builder = expressionBuilder();
 
     builder.append("CREATE SCHEMA ");
     builder.append(table.schemaName());
-    builder.append(DELIMITER);
+    return builder.toString();
+  }
+
+  public String buildSetSearchPathStatement(
+          TableId table
+  ) {
+    ExpressionBuilder builder = expressionBuilder();
+
     builder.append("SET search_path to ");
     builder.append(table.schemaName());
-    builder.append(DELIMITER);
     return builder.toString();
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/dialect/TimescaleDBDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/TimescaleDBDatabaseDialect.java
@@ -17,12 +17,15 @@ package io.confluent.connect.jdbc.dialect;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialectProvider.SubprotocolBasedProvider;
 import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
-import io.confluent.connect.jdbc.util.*;
+import io.confluent.connect.jdbc.util.DateTimeUtils;
+import io.confluent.connect.jdbc.util.ExpressionBuilder;
+import io.confluent.connect.jdbc.util.TableId;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Timestamp;
 
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -67,8 +70,9 @@ public class TimescaleDBDatabaseDialect extends PostgreSqlDatabaseDialect {
   ) {
     // This would create the schema and table then convert the table to a hyper table.
     List<String> sqlQueries = new ArrayList<>();
-    if(table.schemaName() != null)
+    if (table.schemaName() != null) {
       sqlQueries.add(buildCreateSchemaStatement(table));
+    }
     sqlQueries.add(super.buildCreateTableStatement(table, fields));
     sqlQueries.add(buildCreateHyperTableStatement(table));
 
@@ -104,21 +108,22 @@ public class TimescaleDBDatabaseDialect extends PostgreSqlDatabaseDialect {
           Connection connection,
           List<String> statements
   ) throws SQLException {
-    // This overrides the function by catching 'result was returned' error thrown by PSQL when creating hypertables
-    try{
+    // This overrides the function by catching 'result was returned' error thrown by PSQL
+    // when creating hypertables
+    try {
       super.applyDdlStatements(connection, statements);
-    }
-    catch(SQLException e){
-      if(!e.getMessage().contains(HYPERTABLE_WARNING))
+    } catch (SQLException e) {
+      if (!e.getMessage().contains(HYPERTABLE_WARNING)) {
         throw e;
+      }
     }
   }
 
   @Override
   protected String getSqlType(SinkRecordField field) {
-    if (field.schemaName() == Timestamp.LOGICAL_NAME)
+    if (field.schemaName() == Timestamp.LOGICAL_NAME) {
       return "TIMESTAMPTZ";
-    else {
+    } else {
       return super.getSqlType(field);
     }
   }

--- a/src/main/java/io/confluent/connect/jdbc/dialect/TimescaleDBDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/TimescaleDBDatabaseDialect.java
@@ -21,6 +21,7 @@ import io.confluent.connect.jdbc.util.*;
 import org.apache.kafka.common.config.AbstractConfig;
 
 import java.sql.*;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -57,12 +58,16 @@ public class TimescaleDBDatabaseDialect extends PostgreSqlDatabaseDialect {
   }
 
   @Override
-  public String buildCreateTableStatement(
+  public List<String> buildCreateTableStatements(
           TableId table,
           Collection<SinkRecordField> fields
   ) {
     // This would create the table then convert it to a hyper table.
-    return super.buildCreateTableStatement(table, fields).concat(DELIMITER).concat(buildCreateHyperTableStatement(table));
+    List<String> sqlQueries = new ArrayList<>();
+    sqlQueries.add(super.buildCreateTableStatement(table, fields));
+    sqlQueries.add(buildCreateHyperTableStatement(table));
+
+    return sqlQueries;
   }
 
 

--- a/src/main/java/io/confluent/connect/jdbc/dialect/TimescaleDBDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/TimescaleDBDatabaseDialect.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.dialect;
+
+import io.confluent.connect.jdbc.dialect.DatabaseDialectProvider.SubprotocolBasedProvider;
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
+import io.confluent.connect.jdbc.util.*;
+import org.apache.kafka.common.config.AbstractConfig;
+
+import java.sql.*;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * A {@link DatabaseDialect} for TimescaleDB.
+ */
+public class TimescaleDBDatabaseDialect extends PostgreSqlDatabaseDialect {
+
+  /**
+   * The provider for {@link TimescaleDBDatabaseDialect}.
+   */
+  public static class Provider extends SubprotocolBasedProvider {
+    public Provider() {
+      super(TimescaleDBDatabaseDialect.class.getSimpleName(), "postgresql");
+    }
+
+    @Override
+    public DatabaseDialect create(AbstractConfig config) {
+      return new TimescaleDBDatabaseDialect(config);
+    }
+  }
+
+  static final int CHUNK_TIME_INTERVAL = 86400000;
+  static final String DELIMITER = ";";
+  static final String HYPERTABLE_WARNING = "A result was returned when none was expected";
+
+  /**
+   * Create a new dialect instance with the given connector configuration.
+   *
+   * @param config the connector configuration; may not be null
+   */
+  public TimescaleDBDatabaseDialect(AbstractConfig config) {
+    super(config);
+  }
+
+  @Override
+  public String buildCreateTableStatement(
+          TableId table,
+          Collection<SinkRecordField> fields
+  ) {
+    // This would create the table then convert it to a hyper table.
+    return super.buildCreateTableStatement(table, fields).concat(DELIMITER).concat(buildCreateHyperTableStatement(table));
+  }
+
+
+  public String buildCreateHyperTableStatement(
+          TableId table
+  ) {
+    ExpressionBuilder builder = expressionBuilder();
+
+    builder.append("SELECT create_hypertable('");
+    builder.append(table);
+    builder.append("', 'time', migrate_data => TRUE, chunk_time_interval => ");
+    builder.append(CHUNK_TIME_INTERVAL);
+    builder.append(");");
+    return builder.toString();
+  }
+
+  @Override
+  public void applyDdlStatements(
+          Connection connection,
+          List<String> statements
+  ) throws SQLException {
+    // This overrides the function by catching 'result was returned' error thrown by PSQL when creating hypertables
+    try{
+      super.applyDdlStatements(connection, statements);
+    }
+    catch(SQLException e){
+      if(!e.getMessage().contains(HYPERTABLE_WARNING))
+        throw e;
+    }
+  }
+
+
+}

--- a/src/main/java/io/confluent/connect/jdbc/dialect/TimescaleDBDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/TimescaleDBDatabaseDialect.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.dialect;
+
+import io.confluent.connect.jdbc.dialect.DatabaseDialectProvider.SubprotocolBasedProvider;
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
+import io.confluent.connect.jdbc.util.*;
+import org.apache.kafka.common.config.AbstractConfig;
+
+import java.sql.*;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * A {@link DatabaseDialect} for TimescaleDB.
+ */
+public class TimescaleDBDatabaseDialect extends PostgreSqlDatabaseDialect {
+
+  /**
+   * The provider for {@link TimescaleDBDatabaseDialect}.
+   */
+  public static class Provider extends SubprotocolBasedProvider {
+    public Provider() {
+      super(TimescaleDBDatabaseDialect.class.getSimpleName(), "postgresql");
+    }
+
+    @Override
+    public DatabaseDialect create(AbstractConfig config) {
+      return new TimescaleDBDatabaseDialect(config);
+    }
+  }
+
+  static final int CHUNK_TIME_INTERVAL = 86400000;
+  static final String DELIMITER = ";";
+  static final String HYPERTABLE_WARNING = "A result was returned when none was expected";
+
+  /**
+   * Create a new dialect instance with the given connector configuration.
+   *
+   * @param config the connector configuration; may not be null
+   */
+  public TimescaleDBDatabaseDialect(AbstractConfig config) {
+    super(config);
+  }
+
+  public String buildCreateSchemaStatement(
+          TableId table
+  ) {
+    ExpressionBuilder builder = expressionBuilder();
+
+    builder.append("SELECT create_hypertable('");
+    builder.append(table);
+    builder.append("', 'time', migrate_data => TRUE, chunk_time_interval => ");
+    builder.append(CHUNK_TIME_INTERVAL);
+    builder.append(");");
+    return builder.toString();
+  }
+
+  @Override
+  public String buildCreateTableStatement(
+          TableId table,
+          Collection<SinkRecordField> fields
+  ) {
+    // This would create the table then convert it to a hyper table.
+    return super.buildCreateTableStatement(table, fields).concat(DELIMITER).concat(buildCreateHyperTableStatement(table));
+  }
+
+
+  public String buildCreateHyperTableStatement(
+          TableId table
+  ) {
+    ExpressionBuilder builder = expressionBuilder();
+
+    builder.append("SELECT create_hypertable('");
+    builder.append(table);
+    builder.append("', 'time', migrate_data => TRUE, chunk_time_interval => ");
+    builder.append(CHUNK_TIME_INTERVAL);
+    builder.append(");");
+    return builder.toString();
+  }
+
+  @Override
+  public void applyDdlStatements(
+          Connection connection,
+          List<String> statements
+  ) throws SQLException {
+    // This overrides the function by catching 'result was returned' error thrown by PSQL when creating hypertables
+    try{
+      super.applyDdlStatements(connection, statements);
+    }
+    catch(SQLException e){
+      if(!e.getMessage().contains(HYPERTABLE_WARNING))
+        throw e;
+    }
+  }
+
+
+}

--- a/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
@@ -21,7 +21,10 @@ import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialect;
 import io.confluent.connect.jdbc.sink.metadata.FieldsMetadata;
@@ -85,7 +88,8 @@ public class DbStructure {
           String.format("Table %s is missing and auto-creation is disabled", tableId)
       );
     }
-    List<String> sql = dbDialect.buildCreateTableStatements(tableId, fieldsMetadata.allFields.values());
+    List<String> sql = dbDialect.buildCreateTableStatements(tableId,
+            fieldsMetadata.allFields.values());
     log.info("Creating table with sql: {}", sql);
     dbDialect.applyDdlStatements(connection, sql);
   }

--- a/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
@@ -89,9 +89,9 @@ public class DbStructure {
           String.format("Table %s is missing and auto-creation is disabled", tableId)
       );
     }
-    String sql = dbDialect.buildCreateTableStatement(tableId, fieldsMetadata.allFields.values());
+    List<String> sql = dbDialect.buildCreateTableStatements(tableId, fieldsMetadata.allFields.values());
     log.info("Creating table with sql: {}", sql);
-    dbDialect.applyDdlStatements(connection, Collections.singletonList(sql));
+    dbDialect.applyDdlStatements(connection, sql);
   }
 
   /**

--- a/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/DbStructure.java
@@ -21,11 +21,7 @@ import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialect;
 import io.confluent.connect.jdbc.sink.metadata.FieldsMetadata;
@@ -89,9 +85,13 @@ public class DbStructure {
           String.format("Table %s is missing and auto-creation is disabled", tableId)
       );
     }
-    String sql = dbDialect.buildCreateTableStatement(tableId, fieldsMetadata.allFields.values());
-    log.info("Creating table with sql: {}", sql);
-    dbDialect.applyDdlStatements(connection, Collections.singletonList(sql));
+    List<String> statements = new ArrayList<>();
+    String sqlCreateSchema = dbDialect.buildCreateSchemaStatement(tableId);
+    String sqlCreateTable = dbDialect.buildCreateTableStatement(tableId, fieldsMetadata.allFields.values());
+    statements.add(sqlCreateSchema);
+    statements.add(sqlCreateTable);
+    log.info("Creating table with sql: {}", statements);
+    dbDialect.applyDdlStatements(connection, statements);
   }
 
   /**

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -103,19 +103,20 @@ public class JdbcDbWriter {
   }
 
   String destinationSchema(SinkRecord record) {
-    String schemaNameFormat = config.schemaNameFormat;
-    Struct keyData = ((Struct)record.key());
-
     StringBuilder schemaName = new StringBuilder();
-    Pattern pattern = Pattern.compile("\\$\\{(.*?)\\}");
-    Matcher matcher = pattern.matcher(schemaNameFormat);
-    int lastStart = 0;
-    while (matcher.find()) {
-      String subString = schemaNameFormat.substring(lastStart,matcher.start());
-      String key = matcher.group(1);
-      String replacement = keyData.getString(key);
-      schemaName.append(subString).append(replacement);
-      lastStart = matcher.end();
+    String schemaNameFormat = config.schemaNameFormat;
+    if (!schemaNameFormat.isEmpty() && (record.key() instanceof Struct)) {
+      Struct keyData = ((Struct) record.key());
+      Pattern pattern = Pattern.compile("\\$\\{(.*?)\\}");
+      Matcher matcher = pattern.matcher(schemaNameFormat);
+      int lastStart = 0;
+      while (matcher.find()) {
+        String subString = schemaNameFormat.substring(lastStart, matcher.start());
+        String key = matcher.group(1);
+        String replacement = keyData.getString(key);
+        schemaName.append(subString).append(replacement);
+        lastStart = matcher.end();
+      }
     }
 
     return schemaName.toString().toLowerCase();

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -116,6 +116,6 @@ public class JdbcDbWriter {
       lastStart = matcher.end();
     }
 
-    return schemaName.toString();
+    return schemaName.toString().toLowerCase();
   }
 }

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -102,7 +102,7 @@ public class JdbcDbWriter {
 
   String destinationSchema(SinkRecord record) {
     String schemaNameFormat = config.schemaNameFormat;
-    Struct valueStruct = ((Struct)record.value());
+    Struct keyData = ((Struct)record.key());
 
     StringBuilder schemaName = new StringBuilder();
     Pattern pattern = Pattern.compile("\\$\\{(.*?)\\}");
@@ -111,7 +111,7 @@ public class JdbcDbWriter {
     while (matcher.find()) {
       String subString = schemaNameFormat.substring(lastStart,matcher.start());
       String key = matcher.group(1);
-      String replacement = valueStruct.getString(key);
+      String replacement = keyData.getString(key);
       schemaName.append(subString).append(replacement);
       lastStart = matcher.end();
     }

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -34,6 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class JdbcDbWriter {
+  private static final Pattern INLINE_VARIABLE_PATTERN = Pattern.compile("\\$\\{(.*?)\\}");
   private static final Logger log = LoggerFactory.getLogger(JdbcDbWriter.class);
 
   private final JdbcSinkConfig config;
@@ -107,8 +108,7 @@ public class JdbcDbWriter {
     String schemaNameFormat = config.schemaNameFormat;
     if (!schemaNameFormat.isEmpty() && (record.key() instanceof Struct)) {
       Struct keyData = ((Struct) record.key());
-      Pattern pattern = Pattern.compile("\\$\\{(.*?)\\}");
-      Matcher matcher = pattern.matcher(schemaNameFormat);
+      Matcher matcher = INLINE_VARIABLE_PATTERN.matcher(schemaNameFormat);
       int lastStart = 0;
       while (matcher.find()) {
         String subString = schemaNameFormat.substring(lastStart, matcher.start());

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -85,7 +85,9 @@ public class JdbcDbWriter {
   TableId destinationTable(SinkRecord record) {
     StringBuilder name = new StringBuilder();
     final String schemaName = destinationSchema(record);
-    if (!schemaName.isEmpty()) name.append(schemaName).append(".");
+    if (!schemaName.isEmpty()) {
+      name.append(schemaName).append(".");
+    }
     name.append(config.tableNameFormat.replace("${topic}", record.topic()));
 
     final String tableName = name.toString();

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -117,6 +117,7 @@ public class JdbcDbWriter {
         schemaName.append(subString).append(replacement);
         lastStart = matcher.end();
       }
+      schemaName.append(schemaNameFormat.substring(lastStart));
     }
 
     return schemaName.toString().toLowerCase();

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -95,7 +95,7 @@ public class JdbcSinkConfig extends AbstractConfig {
   private static final String TABLE_NAME_FORMAT_DISPLAY = "Table Name Format";
 
   public static final String SCHEMA_NAME_FORMAT = "schema.name.format";
-  private static final String SCHEMA_NAME_FORMAT_DEFAULT = "";
+  private static final String SCHEMA_NAME_FORMAT_DEFAULT = "public";
   private static final String SCHEMA_NAME_FORMAT_DOC =
           "A format string for the destination schema name, which may contain '${key}' as a "
           + "placeholder for a key in the record key."

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -99,7 +99,8 @@ public class JdbcSinkConfig extends AbstractConfig {
   private static final String SCHEMA_NAME_FORMAT_DOC =
           "A format string for the destination schema name, which may contain '${key}' as a "
           + "placeholder for a key in the record key."
-          + "For example, ``${projectId}`` for projectId 'myProject' will map to the schema name 'myProject'.";
+          + "For example, ``${projectId}`` for projectId 'myProject' "
+          + "will map to the schema name 'myProject'.";
   private static final String SCHEMA_NAME_FORMAT_DISPLAY = "Schema Name Format";
 
   public static final String MAX_RETRIES = "max.retries";

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -94,6 +94,12 @@ public class JdbcSinkConfig extends AbstractConfig {
       + "'kafka_orders'.";
   private static final String TABLE_NAME_FORMAT_DISPLAY = "Table Name Format";
 
+  public static final String SCHEMA_NAME_FORMAT = "schema.name.format";
+  private static final String SCHEMA_NAME_FORMAT_DEFAULT = "projectId";
+  private static final String SCHEMA_NAME_FORMAT_DOC =
+          "A format string for the destination schema name.";
+  private static final String SCHEMA_NAME_FORMAT_DISPLAY = "Schema Name Format";
+
   public static final String MAX_RETRIES = "max.retries";
   private static final int MAX_RETRIES_DEFAULT = 10;
   private static final String MAX_RETRIES_DOC =
@@ -349,6 +355,17 @@ public class JdbcSinkConfig extends AbstractConfig {
             ConfigDef.Width.LONG,
             TABLE_NAME_FORMAT_DISPLAY
         )
+          .define(
+                  SCHEMA_NAME_FORMAT,
+                  ConfigDef.Type.STRING,
+                  SCHEMA_NAME_FORMAT_DEFAULT,
+                  ConfigDef.Importance.MEDIUM,
+                  SCHEMA_NAME_FORMAT_DOC,
+                  DATAMAPPING_GROUP,
+                  6,
+                  ConfigDef.Width.LONG,
+                  SCHEMA_NAME_FORMAT_DISPLAY
+          )
         .define(
             PK_MODE,
             ConfigDef.Type.STRING,
@@ -457,6 +474,7 @@ public class JdbcSinkConfig extends AbstractConfig {
   public final String connectionUser;
   public final String connectionPassword;
   public final String tableNameFormat;
+  public final String schemaNameFormat;
   public final int batchSize;
   public final boolean deleteEnabled;
   public final int maxRetries;
@@ -478,6 +496,7 @@ public class JdbcSinkConfig extends AbstractConfig {
     connectionUser = getString(CONNECTION_USER);
     connectionPassword = getPasswordValue(CONNECTION_PASSWORD);
     tableNameFormat = getString(TABLE_NAME_FORMAT).trim();
+    schemaNameFormat = getString(SCHEMA_NAME_FORMAT).trim();
     batchSize = getInt(BATCH_SIZE);
     deleteEnabled = getBoolean(DELETE_ENABLED);
     maxRetries = getInt(MAX_RETRIES);

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -95,9 +95,11 @@ public class JdbcSinkConfig extends AbstractConfig {
   private static final String TABLE_NAME_FORMAT_DISPLAY = "Table Name Format";
 
   public static final String SCHEMA_NAME_FORMAT = "schema.name.format";
-  private static final String SCHEMA_NAME_FORMAT_DEFAULT = "projectId";
+  private static final String SCHEMA_NAME_FORMAT_DEFAULT = "";
   private static final String SCHEMA_NAME_FORMAT_DOC =
-          "A format string for the destination schema name.";
+          "A format string for the destination schema name, which may contain '${key}' as a "
+          + "placeholder for a key in the record key."
+          + "For example, ``${projectId}`` for projectId 'myProject' will map to the schema name 'myProject'.";
   private static final String SCHEMA_NAME_FORMAT_DISPLAY = "Schema Name Format";
 
   public static final String MAX_RETRIES = "max.retries";
@@ -127,7 +129,7 @@ public class JdbcSinkConfig extends AbstractConfig {
   private static final String DELETE_ENABLED_DISPLAY = "Enable deletes";
 
   public static final String AUTO_CREATE = "auto.create";
-  private static final String AUTO_CREATE_DEFAULT = "false";
+  private static final String AUTO_CREATE_DEFAULT = "true";
   private static final String AUTO_CREATE_DOC =
       "Whether to automatically create the destination table based on record schema if it is "
       + "found to be missing by issuing ``CREATE``.";

--- a/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/DateTimeUtils.java
@@ -65,6 +65,14 @@ public class DateTimeUtils {
     }).format(date);
   }
 
+  public static String formatTimestamptz(Date date, TimeZone timeZone) {
+    return TIMEZONE_TIMESTAMP_FORMATS.get().computeIfAbsent(timeZone, aTimeZone -> {
+      SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSX");
+      sdf.setTimeZone(aTimeZone);
+      return sdf;
+    }).format(date);
+  }
+
   private DateTimeUtils() {
   }
 }

--- a/src/main/resources/META-INF/services/io.confluent.connect.jdbc.dialect.DatabaseDialectProvider
+++ b/src/main/resources/META-INF/services/io.confluent.connect.jdbc.dialect.DatabaseDialectProvider
@@ -9,3 +9,4 @@ io.confluent.connect.jdbc.dialect.SqlServerDatabaseDialect$Provider
 io.confluent.connect.jdbc.dialect.SapHanaDatabaseDialect$Provider
 io.confluent.connect.jdbc.dialect.SybaseDatabaseDialect$Provider
 io.confluent.connect.jdbc.dialect.VerticaDatabaseDialect$Provider
+io.confluent.connect.jdbc.dialect.TimescaleDBDatabaseDialect$Provider


### PR DESCRIPTION
- Adds TimescaleDB dialect (and allow creation of hypertables)
- Allows adding of multiple createTable statements
- Allows schema creation and setting schema name format in the connector config
- Adds support for `TIMESTAMPTZ` data type for PostgreSQL databases
- Use confluent `5.5.0` instead of `6.0.0-SNAPSHOT` 